### PR TITLE
Add option to timeout based on total time spent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
-*.iml
-.idea/
+.factorypath
 target/
+.settings
+.classpath
+.project
+.vscode
+/bin
+*.iml
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-.factorypath
-target/
-.settings
-.classpath
-.project
-.vscode
-/bin
 *.iml
+.idea/
+target/

--- a/engine/core/src/main/java/com/codingame/gameengine/core/AbstractPlayer.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/AbstractPlayer.java
@@ -27,7 +27,7 @@ abstract public class AbstractPlayer {
     protected int index;
     private List<String> inputs = new ArrayList<>();
     private List<String> outputs;
-    private int totalTimeUsed;
+    private long totalTimeSpent; // in nanoseconds
     private boolean timeout;
     private int score;
     private boolean hasBeenExecuted;
@@ -156,13 +156,12 @@ abstract public class AbstractPlayer {
         this.outputs = outputs;
     }
 
-    public final int getTotalTimeUsed() {
-        return totalTimeUsed;
+    public final int getTotalTimeSpentMs() {
+        return (int) Math.round(totalTimeSpent / 1e6);
     }
 
-    // TODO
-    final void addTimeUsed(int time) {
-        totalTimeUsed += time;
+    final void addTimeSpent(long time) {
+        totalTimeSpent += time;
     }
 
     final void setTimeout(boolean timeout) {

--- a/engine/core/src/main/java/com/codingame/gameengine/core/AbstractPlayer.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/AbstractPlayer.java
@@ -27,6 +27,7 @@ abstract public class AbstractPlayer {
     protected int index;
     private List<String> inputs = new ArrayList<>();
     private List<String> outputs;
+    private int totalTimeUsed;
     private boolean timeout;
     private int score;
     private boolean hasBeenExecuted;
@@ -153,6 +154,15 @@ abstract public class AbstractPlayer {
 
     final void setOutputs(List<String> outputs) {
         this.outputs = outputs;
+    }
+
+    public final int getTotalTimeUsed() {
+        return totalTimeUsed;
+    }
+
+    // TODO
+    final void addTimeUsed(int time) {
+        totalTimeUsed += time;
     }
 
     final void setTimeout(boolean timeout) {

--- a/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
@@ -37,13 +37,10 @@ abstract public class GameManager<T extends AbstractPlayer> {
     private static final int GAME_SUMMARY_PER_TURN_HARD_QUOTA = 800;
     private static final int GAME_DURATION_HARD_QUOTA = 30_000;
     private static final int GAME_DURATION_SOFT_QUOTA = 25_000;
-    private static final int MAX_TURN_TIME = GAME_DURATION_SOFT_QUOTA;
-    private static final int MIN_TURN_TIME = 50;
 
     protected List<T> players;
     private int maxTurns = 200;
-    private int turnMaxTime = 50;
-    private int firstTurnMaxTime = 1000;
+    private final TimeoutSettings timeoutSettings = new TimeoutSettings();
     private Integer turn = null;
     private int frame = 0;
     private boolean gameEnd = false;
@@ -191,7 +188,7 @@ abstract public class GameManager<T extends AbstractPlayer> {
             if (nbrOutputLines > 0) {
                 addTurnTime();
             }
-            dumpNextPlayerInfos(player.getIndex(), nbrOutputLines, player.hasNeverBeenExecuted() ? firstTurnMaxTime : turnMaxTime);
+            dumpNextPlayerInfos(player.getIndex(), nbrOutputLines, timeoutSettings.getMaxTurnTime(player));
 
             // READ PLAYER OUTPUTS
             iCmd = InputCommand.parse(s.nextLine());
@@ -445,56 +442,8 @@ abstract public class GameManager<T extends AbstractPlayer> {
         return maxTurns;
     }
 
-    /**
-     * Set the timeout delay for every player. This value can be updated during a game and will be used by execute(). Default is 50ms.
-     * 
-     * @param turnMaxTime
-     *            Duration in milliseconds.
-     * @throws IllegalArgumentException
-     *             if turnMaxTime &lt; 50 or &gt; 25000
-     */
-    public void setTurnMaxTime(int turnMaxTime) throws IllegalArgumentException {
-        if (turnMaxTime < MIN_TURN_TIME) {
-            throw new IllegalArgumentException("Invalid turn max time : stay above 50ms");
-        } else if (turnMaxTime > MAX_TURN_TIME) {
-            throw new IllegalArgumentException("Invalid turn max time : stay under 25s");
-        }
-        this.turnMaxTime = turnMaxTime;
-    }
-    
-    /**
-     * Set the timeout delay of the first turn for every player. Default is 1000ms.
-     * 
-     * @param firstTurnMaxTime
-     *            Duration in milliseconds.
-     * @throws IllegalArgumentException
-     *             if firstTurnMaxTime &lt; 50 or &gt; 25000
-     */
-    public void setFirstTurnMaxTime(int firstTurnMaxTime) throws IllegalArgumentException {
-        if (firstTurnMaxTime < MIN_TURN_TIME) {
-            throw new IllegalArgumentException("Invalid turn max time : stay above 50ms");
-        } else if (firstTurnMaxTime > MAX_TURN_TIME) {
-            throw new IllegalArgumentException("Invalid turn max time : stay under 25s");
-        }
-        this.firstTurnMaxTime = firstTurnMaxTime;
-    }
-
-    /**
-     * Get the timeout delay for every player.
-     * 
-     * @return the current timeout duration in milliseconds.
-     */
-    public int getTurnMaxTime() {
-        return turnMaxTime;
-    }
-    
-    /**
-     * Get the timeout delay of the first turn for every player.
-     * 
-     * @return the first turn timeout duration in milliseconds.
-     */
-    public int getFirstTurnMaxTime() {
-        return firstTurnMaxTime;
+    public TimeoutSettings getTimeoutSettings() {
+        return timeoutSettings;
     }
 
     /**
@@ -577,7 +526,7 @@ abstract public class GameManager<T extends AbstractPlayer> {
     }
 
     private void addTurnTime() {
-        totalTurnTime += turnMaxTime;
+        totalTurnTime += 0; // TODO
         if (totalTurnTime > GAME_DURATION_HARD_QUOTA) {
             throw new RuntimeException(String.format("Total game duration too long (>%dms)", GAME_DURATION_HARD_QUOTA));
         } else if (totalTurnTime > GAME_DURATION_SOFT_QUOTA) {

--- a/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
@@ -185,18 +185,17 @@ abstract public class GameManager<T extends AbstractPlayer> {
             dumpView();
             dumpInfos();
             dumpNextPlayerInput(player.getInputs().toArray(new String[0]));
-            if (nbrOutputLines > 0) {
-                addTurnTime();
-            }
             dumpNextPlayerInfos(player.getIndex(), nbrOutputLines, timeoutSettings.getMaxTurnTime(player));
 
             // READ PLAYER OUTPUTS
             iCmd = InputCommand.parse(s.nextLine());
             if (iCmd.cmd == InputCommand.Command.SET_PLAYER_OUTPUT) {
-                List<String> output = new ArrayList<>(iCmd.lineCount);
-                for (int i = 0; i < iCmd.lineCount; i++) {
+                final long timeSpent = Long.parseLong(s.nextLine());
+                List<String> output = new ArrayList<>(iCmd.lineCount - 1);
+                for (int i = 0; i < iCmd.lineCount - 1; i++) {
                     output.add(s.nextLine());
                 }
+                player.addTimeSpent(timeSpent);
                 player.setOutputs(output);
             } else if (iCmd.cmd == InputCommand.Command.SET_PLAYER_TIMEOUT) {
                 player.setTimeout(true);
@@ -522,20 +521,6 @@ abstract public class GameManager<T extends AbstractPlayer> {
         } else if (!summaryWarning) {
             log.warn("Warning: the game summary is full. Please try to send less data.");
             summaryWarning = true;
-        }
-    }
-
-    private void addTurnTime() {
-        totalTurnTime += 0; // TODO
-        if (totalTurnTime > GAME_DURATION_HARD_QUOTA) {
-            throw new RuntimeException(String.format("Total game duration too long (>%dms)", GAME_DURATION_HARD_QUOTA));
-        } else if (totalTurnTime > GAME_DURATION_SOFT_QUOTA) {
-            log.warn(
-                String.format(
-                    "Warning: too many turns and/or too much time allocated to players per turn (%dms/%dms)",
-                    totalTurnTime, GAME_DURATION_HARD_QUOTA
-                )
-            );
         }
     }
 

--- a/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/GameManager.java
@@ -35,8 +35,6 @@ abstract public class GameManager<T extends AbstractPlayer> {
     private static final int VIEW_DATA_TOTAL_HARD_QUOTA = 1024 * 1024;
     private static final int GAME_SUMMARY_TOTAL_HARD_QUOTA = 512 * 1024;
     private static final int GAME_SUMMARY_PER_TURN_HARD_QUOTA = 800;
-    private static final int GAME_DURATION_HARD_QUOTA = 30_000;
-    private static final int GAME_DURATION_SOFT_QUOTA = 25_000;
 
     protected List<T> players;
     private int maxTurns = 200;
@@ -69,7 +67,6 @@ abstract public class GameManager<T extends AbstractPlayer> {
     private boolean outputsRead = false;
     private int totalViewDataBytesSent = 0;
     private int totalGameSummaryBytes = 0;
-    private int totalTurnTime = 0;
 
     private boolean viewWarning, summaryWarning;
 

--- a/engine/core/src/main/java/com/codingame/gameengine/core/MultiplayerGameManager.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/MultiplayerGameManager.java
@@ -111,7 +111,6 @@ public final class MultiplayerGameManager<T extends AbstractMultiplayerPlayer> e
      * @return the list of active players.
      */
     public List<T> getActivePlayers() {
-        // TODO: could be optimized with a list of active players updated on player.deactivate().
         return players.stream().filter(p -> p.isActive()).collect(Collectors.toList());
     }
 

--- a/engine/core/src/main/java/com/codingame/gameengine/core/TimeoutSettings.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/TimeoutSettings.java
@@ -1,7 +1,10 @@
 package com.codingame.gameengine.core;
 
-// TODO: check validity of arguments
 public final class TimeoutSettings {
+
+    private static final int MIN_TURN_TIME  =     50;
+    private static final int MAX_TURN_TIME  = 25_000;
+    private static final int MAX_TOTAL_TIME = 30_000; // TODO: "hard quota"?
 
     private Mode mode;
     private int limit; // ms
@@ -12,12 +15,20 @@ public final class TimeoutSettings {
     }
 
     public void set(final int total) {
+        if (total < MIN_TURN_TIME || total > MAX_TOTAL_TIME)
+            throw new IllegalArgumentException("`total` cannot be less than 50ms or greater than 30s");
+
         mode = Mode.TOTAL;
         limit = total;
         limitFirst = -1;
     }
 
     public void set(final int perTurn, final int first) {
+        if (perTurn < MIN_TURN_TIME || perTurn > MAX_TURN_TIME)
+            throw new IllegalArgumentException("`perTurn` cannot be less than 50ms or greater than 25s");
+        if (first < MIN_TURN_TIME || first > MAX_TURN_TIME)
+            throw new IllegalArgumentException("`first` cannot be less than 50ms or greater than 25s");
+
         mode = Mode.PER_TURN;
         limit = perTurn;
         limitFirst = first;

--- a/engine/core/src/main/java/com/codingame/gameengine/core/TimeoutSettings.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/TimeoutSettings.java
@@ -1,0 +1,35 @@
+package com.codingame.gameengine.core;
+
+// TODO: check validity of arguments
+public final class TimeoutSettings {
+
+    private Mode mode;
+    private int limit; // ms
+    private int limitFirst;
+
+    public TimeoutSettings() {
+        set(50, 1000);
+    }
+
+    public void set(final int total) {
+        mode = Mode.TOTAL;
+        limit = total;
+        limitFirst = -1;
+    }
+
+    public void set(final int perTurn, final int first) {
+        mode = Mode.PER_TURN;
+        limit = perTurn;
+        limitFirst = first;
+    }
+
+    public <T extends AbstractPlayer> int getMaxTurnTime(final T player) {
+        if (mode == Mode.PER_TURN)
+            return player.hasNeverBeenExecuted() ? limitFirst : limit;
+        else
+            return Math.max(limit - player.getTotalTimeUsed(), 0);
+    }
+
+    private enum Mode { PER_TURN, TOTAL }
+
+}

--- a/engine/core/src/main/java/com/codingame/gameengine/core/TimeoutSettings.java
+++ b/engine/core/src/main/java/com/codingame/gameengine/core/TimeoutSettings.java
@@ -27,7 +27,7 @@ public final class TimeoutSettings {
         if (mode == Mode.PER_TURN)
             return player.hasNeverBeenExecuted() ? limitFirst : limit;
         else
-            return Math.max(limit - player.getTotalTimeUsed(), 0);
+            return Math.max(limit - player.getTotalTimeSpentMs(), 0);
     }
 
     private enum Mode { PER_TURN, TOTAL }

--- a/engine/modules/entities/src/main/java/com/codingame/gameengine/module/entities/GraphicEntityModule.java
+++ b/engine/modules/entities/src/main/java/com/codingame/gameengine/module/entities/GraphicEntityModule.java
@@ -26,8 +26,6 @@ import com.google.inject.Singleton;
 @Singleton
 public class GraphicEntityModule implements Module {
 
-    //TODO: extra properties for Texts (text wrapping, alignment, ...)
-
     static int ENTITY_COUNT = 0;
 
     private List<SpriteSheetSplitter> newSpriteSheetSplitters;

--- a/runner/src/main/java/com/codingame/gameengine/runner/GameRunner.java
+++ b/runner/src/main/java/com/codingame/gameengine/runner/GameRunner.java
@@ -21,6 +21,7 @@ import com.codingame.gameengine.runner.Command.InputCommand;
 import com.codingame.gameengine.runner.Command.OutputCommand;
 import com.codingame.gameengine.runner.dto.AgentDto;
 import com.codingame.gameengine.runner.dto.GameResultDto;
+import com.codingame.gameengine.runner.dto.PlayerOutputDto;
 import com.codingame.gameengine.runner.dto.TooltipDto;
 import com.codingame.gameengine.runner.simulate.AgentData;
 import com.codingame.gameengine.runner.simulate.GameResult;
@@ -139,18 +140,18 @@ abstract class GameRunner {
                 NextPlayerInfo nextPlayerInfo = new NextPlayerInfo(
                     turnInfo.get(InputCommand.NEXT_PLAYER_INFO).orElse(null)
                 );
-                String nextPlayerOutput = getNextPlayerOutput(
+                PlayerOutputDto nextPlayerOutput = getNextPlayerOutput(
                     nextPlayerInfo,
                     turnInfo.get(InputCommand.NEXT_PLAYER_INPUT).orElse(null)
                 );
 
                 for (Agent a : players) {
-                    gameResult.outputs.get(String.valueOf(a.getAgentId())).add(a.getAgentId() == nextPlayerInfo.nextPlayer ? nextPlayerOutput : null);
+                    gameResult.outputs.get(String.valueOf(a.getAgentId())).add(a.getAgentId() == nextPlayerInfo.nextPlayer ? nextPlayerOutput.output : null);
                 }
 
-                if (nextPlayerOutput != null) {
+                if (nextPlayerOutput.output != null) {
                     log.info("\t=== Read from player");
-                    log.info(nextPlayerOutput);
+                    log.info(nextPlayerOutput.output);
                     log.info("\t=== End Player");
                     sendPlayerOutput(nextPlayerOutput, nextPlayerInfo.nbLinesNextOutput);
                 } else {
@@ -244,9 +245,9 @@ abstract class GameRunner {
         }
     }
 
-    private void sendPlayerOutput(String output, int nbLines) {
-        String[] lines = output.split("(\\n|\\r\\n)", -1);
-        Command command = new Command(OutputCommand.SET_PLAYER_OUTPUT, Arrays.copyOfRange(lines, 0, nbLines));
+    private void sendPlayerOutput(PlayerOutputDto outputDto, int nbLines) {
+        String[] lines = (outputDto.timeSpent + "\n" + outputDto.output).split("(\\n|\\r\\n)", -1);
+        Command command = new Command(OutputCommand.SET_PLAYER_OUTPUT, Arrays.copyOfRange(lines, 0, nbLines + 1));
         referee.sendInput(command.toString());
     }
 
@@ -255,15 +256,16 @@ abstract class GameRunner {
         referee.sendInput(command.toString());
     }
 
-    private String getNextPlayerOutput(NextPlayerInfo nextPlayerInfo, String nextPlayerInput) {
+    private PlayerOutputDto getNextPlayerOutput(NextPlayerInfo nextPlayerInfo, String nextPlayerInput) {
         Agent player = players.get(nextPlayerInfo.nextPlayer);
 
         // Send player input to input queue
         queues.get(nextPlayerInfo.nextPlayer).offer(nextPlayerInput);
 
         // Wait for player output then read error
-        // TODO: measure and report back time
+        long timeSpent = System.nanoTime();
         String playerOutput = player.getOutput(nextPlayerInfo.nbLinesNextOutput, nextPlayerInfo.timeout);
+        timeSpent = System.nanoTime() - timeSpent;
         if (playerOutput != null)
             playerOutput = playerOutput.replace('\r', '\n');
 
@@ -279,19 +281,19 @@ abstract class GameRunner {
             }
             // Read this turns stderr and the crash output
             readError(player);
-            return null; // ==> timeout
+            return new PlayerOutputDto(null, timeSpent); // ==> timeout
         }
 
         if ((playerOutput != null) && playerOutput.isEmpty() && (nextPlayerInfo.nbLinesNextOutput == 1)) {
-            return "\n";
+            return new PlayerOutputDto("\n", timeSpent);
         }
         if (
             (playerOutput != null) && (playerOutput.length() > 0)
                 && (playerOutput.charAt(playerOutput.length() - 1) != '\n')
         ) {
-            return playerOutput + '\n';
+            return new PlayerOutputDto(playerOutput + '\n', timeSpent);
         }
-        return playerOutput; // ==> timeout if null
+        return new PlayerOutputDto(playerOutput, timeSpent); // ==> timeout if `playerOutput` is null
     }
 
     private GameTurnInfo readGameInfo(int round) {

--- a/runner/src/main/java/com/codingame/gameengine/runner/GameRunner.java
+++ b/runner/src/main/java/com/codingame/gameengine/runner/GameRunner.java
@@ -262,6 +262,7 @@ abstract class GameRunner {
         queues.get(nextPlayerInfo.nextPlayer).offer(nextPlayerInput);
 
         // Wait for player output then read error
+        // TODO: measure and report back time
         String playerOutput = player.getOutput(nextPlayerInfo.nbLinesNextOutput, nextPlayerInfo.timeout);
         if (playerOutput != null)
             playerOutput = playerOutput.replace('\r', '\n');
@@ -278,7 +279,7 @@ abstract class GameRunner {
             }
             // Read this turns stderr and the crash output
             readError(player);
-            return null;
+            return null; // ==> timeout
         }
 
         if ((playerOutput != null) && playerOutput.isEmpty() && (nextPlayerInfo.nbLinesNextOutput == 1)) {
@@ -290,7 +291,7 @@ abstract class GameRunner {
         ) {
             return playerOutput + '\n';
         }
-        return playerOutput;
+        return playerOutput; // ==> timeout if null
     }
 
     private GameTurnInfo readGameInfo(int round) {

--- a/runner/src/main/java/com/codingame/gameengine/runner/JavaPlayerAgent.java
+++ b/runner/src/main/java/com/codingame/gameengine/runner/JavaPlayerAgent.java
@@ -93,13 +93,10 @@ public class JavaPlayerAgent extends Agent {
             javaRunnerThread.interrupt();
             try {
                 javaRunnerThread.join(100);
-            } catch (InterruptedException ie) {
-                // TODO
-            }
+            } catch (InterruptedException ignored) {}
             if (javaRunnerThread.isAlive()) {
-                // TODO
                 javaRunnerThread.interrupt();
-//                 javaRunnerThread.destroy();
+             // javaRunnerThread.destroy();
                 javaRunnerThread.stop();
             }
         }

--- a/runner/src/main/java/com/codingame/gameengine/runner/dto/PlayerOutputDto.java
+++ b/runner/src/main/java/com/codingame/gameengine/runner/dto/PlayerOutputDto.java
@@ -1,0 +1,13 @@
+package com.codingame.gameengine.runner.dto;
+
+public final class PlayerOutputDto {
+
+    public final String output; // nullable!
+    public final long timeSpent; // in nanoseconds
+
+    public PlayerOutputDto(final String output, final long timeSpent) {
+        this.output = output;
+        this.timeSpent = timeSpent;
+    }
+
+}


### PR DESCRIPTION
The new features are:
- `getTotalTimeSpentMs` in `AbstractPlayer`
- `getTimeoutSettings` in `GameManager` where you can:
  - set the time limit, either total or per-turn (with `set`)
  - get the max amount of time a player can spend (with `getMaxTurnTime`)